### PR TITLE
Allow users to not keep other schools in SiSoPi 

### DIFF
--- a/ucs-school-import/modules/ucsschool/importer/mass_import/sisopi_user_import.py
+++ b/ucs-school-import/modules/ucsschool/importer/mass_import/sisopi_user_import.py
@@ -80,6 +80,7 @@ class SingleSourcePartialUserImport(UserImport):
 		"""
 		super(SingleSourcePartialUserImport, self).__init__(dry_run)
 		self.limbo_ou = self.config.get('limbo_ou')
+		self.dont_keep_other_schools = self.config.get('dont_keep_other_schools', False)
 
 	def prepare_imported_user(self, imported_user, old_user):  # type: (ImportUser, Optional[ImportUser]) -> ImportUser
 		"""
@@ -121,6 +122,14 @@ class SingleSourcePartialUserImport(UserImport):
 				imported_user.school = self.config['school']
 				imported_user.schools = [self.config['school']]
 				imported_user.reactivate()
+			elif self.dont_keep_other_schools is True:
+				self.logger.info(
+				    'User %r exists in other school(s). Moving to currently being imported school %r without keeping '
+				    'other schools because dont_keep_other_schools is true in config.',
+					old_user, self.config['school']
+				)
+				imported_user.school = self.config['school']
+				imported_user.schools.append(self.config['school'])
 			else:
 				self.logger.debug(
 					'config["school"]=%r config["limbo_ou"]=%r imported_user.school=%r imported_user.schools=%r '

--- a/ucs-school-import/usr/share/doc/ucs-school-import-http-api/source/sisopi.rst
+++ b/ucs-school-import/usr/share/doc/ucs-school-import-http-api/source/sisopi.rst
@@ -46,3 +46,8 @@ Set the UCR variable ``ucsschool/import/http_api/set_source_uid`` to ``no`` and 
 
 	ucr set ucsschool/import/http_api/set_source_uid=no
 	service ucs-school-import-http-api restart
+
+
+*If you want imported users to only be a member of one school at a time*, namely the one they were imported into lastly, and be immediately moved from any other school into the one being imported currently, the following config parameter can be set. Normally this behaviour is not wanted, thus the parameter is ``false`` by default. The imported users' memberships in school classes belonging to schools different from the one being imported currently will also be removed.
+
+* ``dont_keep_other_schools`` *must* be ``true``

--- a/ucs-school-import/usr/share/ucs-school-import/checks/sisopi.py
+++ b/ucs-school-import/usr/share/ucs-school-import/checks/sisopi.py
@@ -65,4 +65,8 @@ class SingleSourcePartialImportConfigurationChecks(ConfigurationChecks):
 
 	def test_school_not_limbo(self):
 		if self.config['school'] == self.config['limbo_ou']:
-				raise InitialisationError('Importing into limbo ({!r}) OU is forbidden.'.format(self.config['limbo_ou']))
+			raise InitialisationError('Importing into limbo ({!r}) OU is forbidden.'.format(self.config['limbo_ou']))
+
+	def test_dont_keep_other_schools(self):
+		if type(self.config.get('dont_keep_other_schools', False)) is not bool:
+			raise InitialisationError('Non-boolean value configured for dont_keep_other_schools')


### PR DESCRIPTION
Thank you for providing a pull request!

## Please make sure you considered the following things

- [x] I read the [contribution guidelines](./CONTRIBUTING.md).
- [x] I read the [code of conduct](./CODE_OF_CONDUCT).
- [x] I created a bug report in the [Univention Bugzilla](https://forge.univention.org/bugzilla/index.cgi).
- [x] I will add a bugzilla comment about this pull request.

## Link to the issue in Bugzilla

https://forge.univention.org/bugzilla/show_bug.cgi?id=50330

## Description of the changes


* **What kind of change does this PR introduce?** (Bugfix, feature, documentation update, cleanup, security issue, performance enhancement)
This PR adds a feature to ucs-school-import, namely the SiSoPi importer. When a user is being imported into school 1 and later into school 2 the SiSoPi importer modifies the existing user object so that the user is present in both schools simultaneously. Usually this is the desired behaviour. However, at least one customer needs a different behaviour: They need the users to only be present in one school at a time while still using the SiSoPi scenario. This has both technical and organizational reasons.
This specific scenario is probably relatively uncommon but since it only requires a minor change I think we can merge it into U@S.

I have also fixed an indentation in ucs-school-import/checks/sisopi.py
If that shall be a separate PR, I'll gladly revert that.

* **How can we reproduce the issue?** (Which environment? Is there a test case? Which commands need to be executed? Which UMC modules are involed?)
Import a user into school 1 using ucs-school-import with the SiSoPi importer; import the same user into school 2. 

* **To which UCS and UCS@school version does the issue apply?**
Technically all versions of ucs-school-import but more specifically all UCS@school versions since 4.3 v5, when the SiSoPi import was introduced initially

* **Please list relevant screenshots, error messages, logs or tracebacks** (If not already in the bugzilla)
This introduces a new feature, so there are no error messages.

* **Are there any breaking or API changes?** (if so, please describe them)
No, the new mechanism isn't activated by default.

* **Are there changes in the documentation necessary?**
Yes

* **Are there descriptions for newly introduced UCR variables?**
No